### PR TITLE
Handle missing Firebase credentials

### DIFF
--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -44,6 +44,11 @@ class FirebaseCredentialNotSet(ConfigError):
         super().__init__(message="FIREBASE_CREDENTIALS 環境變數未設定")
 
 
+class FirebaseCredentialFileNotFound(ConfigError):
+    def __init__(self, path: str):
+        super().__init__(message=f"Firebase 憑證檔案不存在: {path}")
+
+
 class GCSCredentialNotSet(ConfigError):
     def __init__(self):
         super().__init__(message="GCS_CREDENTIALS 環境變數未設定")

--- a/app/core/firebase_app.py
+++ b/app/core/firebase_app.py
@@ -2,7 +2,10 @@
 
 from firebase_admin import credentials, initialize_app
 from app.core.config import settings
-from app.core.errors import FirebaseCredentialNotSet
+from app.core.errors import (
+    FirebaseCredentialFileNotFound,
+    FirebaseCredentialNotSet,
+)
 
 _app = None  # 單例實例
 
@@ -19,6 +22,10 @@ def get_firebase_app():
     if not settings.FIREBASE_CREDENTIALS:
         raise FirebaseCredentialNotSet()
 
-    cred = credentials.Certificate(settings.FIREBASE_CREDENTIALS)
+    try:
+        cred = credentials.Certificate(settings.FIREBASE_CREDENTIALS)
+    except FileNotFoundError:
+        raise FirebaseCredentialFileNotFound(settings.FIREBASE_CREDENTIALS)
+
     _app = initialize_app(cred)
     return _app

--- a/app/core/firestore_client.py
+++ b/app/core/firestore_client.py
@@ -3,7 +3,10 @@
 from google.cloud import firestore
 from google.oauth2 import service_account
 from app.core.config import settings
-from app.core.errors import FirebaseCredentialNotSet
+from app.core.errors import (
+    FirebaseCredentialFileNotFound,
+    FirebaseCredentialNotSet,
+)
 
 _db = None  # 單例實例
 
@@ -20,8 +23,12 @@ def get_firestore_client():
     if not settings.FIREBASE_CREDENTIALS:
         raise FirebaseCredentialNotSet()
 
-    credentials = service_account.Credentials.from_service_account_file(
-        settings.FIREBASE_CREDENTIALS
-    )
+    try:
+        credentials = service_account.Credentials.from_service_account_file(
+            settings.FIREBASE_CREDENTIALS
+        )
+    except FileNotFoundError:
+        raise FirebaseCredentialFileNotFound(settings.FIREBASE_CREDENTIALS)
+
     _db = firestore.Client(credentials=credentials)
     return _db

--- a/tests/test_firebase_clients.py
+++ b/tests/test_firebase_clients.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch
+
+import pytest
+
+from app.core import firebase_app, firestore_client
+from app.core.config import settings
+from app.core.errors import FirebaseCredentialFileNotFound
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    firebase_app._app = None
+    firestore_client._db = None
+    yield
+    firebase_app._app = None
+    firestore_client._db = None
+
+
+def test_get_firebase_app_valid(tmp_path):
+    cred_file = tmp_path / "cred.json"
+    cred_file.write_text("{}")
+    settings.FIREBASE_CREDENTIALS = str(cred_file)
+
+    with patch("app.core.firebase_app.credentials.Certificate") as cert, patch(
+        "app.core.firebase_app.initialize_app"
+    ) as init:
+        cert.return_value = "cert"
+        init.return_value = "app"
+
+        app = firebase_app.get_firebase_app()
+
+        assert app == "app"
+        cert.assert_called_with(str(cred_file))
+        init.assert_called_with("cert")
+
+
+def test_get_firebase_app_invalid(tmp_path):
+    settings.FIREBASE_CREDENTIALS = str(tmp_path / "missing.json")
+    with patch(
+        "app.core.firebase_app.credentials.Certificate",
+        side_effect=FileNotFoundError,
+    ):
+        with pytest.raises(FirebaseCredentialFileNotFound):
+            firebase_app.get_firebase_app()
+
+
+def test_get_firestore_client_valid(tmp_path):
+    cred_file = tmp_path / "cred.json"
+    cred_file.write_text("{}")
+    settings.FIREBASE_CREDENTIALS = str(cred_file)
+
+    with patch(
+        "app.core.firestore_client.service_account.Credentials.from_service_account_file"
+    ) as from_file, patch("app.core.firestore_client.firestore.Client") as client:
+        from_file.return_value = "creds"
+        client.return_value = "db"
+
+        db = firestore_client.get_firestore_client()
+
+        assert db == "db"
+        from_file.assert_called_with(str(cred_file))
+        client.assert_called_with(credentials="creds")
+
+
+def test_get_firestore_client_invalid(tmp_path):
+    settings.FIREBASE_CREDENTIALS = str(tmp_path / "missing.json")
+    with patch(
+        "app.core.firestore_client.service_account.Credentials.from_service_account_file",
+        side_effect=FileNotFoundError,
+    ):
+        with pytest.raises(FirebaseCredentialFileNotFound):
+            firestore_client.get_firestore_client()


### PR DESCRIPTION
## Summary
- improve errors for missing Firebase credential files
- handle credential file errors in firebase app and Firestore client
- test firebase app and Firestore credential loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684110db1e1883309ed5c933e6a79da0