### PR TITLE
Fix datetime serialization in JSON responses

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -31,7 +31,7 @@ def google_login(data: LoginRequest):
     response = JSONResponse(
         content=SuccessResponse(
             data=LoginResponse(access_token=access_token, user=user)
-        ).model_dump()
+        ).model_dump(mode="json")
     )
 
     response.set_cookie(
@@ -70,7 +70,7 @@ def refresh_token(refresh_token: str = Cookie(None)):
         response = JSONResponse(
             content=SuccessResponse(
                 data=LoginResponse(access_token=new_access_token, user=user)
-            ).model_dump()
+            ).model_dump(mode="json")
         )
 
         response.set_cookie(

--- a/app/core/exception.py
+++ b/app/core/exception.py
@@ -16,7 +16,7 @@ def register_exception_handlers(app: FastAPI):
                 error=ErrorObject(
                     code=exc.status_code, message=exc.message, type=exc.type
                 )
-            ).model_dump(),
+            ).model_dump(mode="json"),
         )
 
     @app.exception_handler(RequestValidationError)
@@ -29,7 +29,7 @@ def register_exception_handlers(app: FastAPI):
                 error=ErrorObject(
                     code=422, message="Validation Failed", type="ValidationError"
                 )
-            ).model_dump(),
+            ).model_dump(mode="json"),
         )
 
     @app.exception_handler(Exception)
@@ -40,5 +40,5 @@ def register_exception_handlers(app: FastAPI):
                 error=ErrorObject(
                     code=500, message="Internal Server Error", type="ServerError"
                 )
-            ).model_dump(),
+            ).model_dump(mode="json"),
         )


### PR DESCRIPTION
## Summary
- fix `JSONResponse` serialization by using `model_dump(mode="json")`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684255c39a1483309a2c631cc5067291